### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@ S3 upload tool using Guzzle and ReactPHP
 
 ## Installation ##
 
-Installation is easy with composer just add ReactGuzzle to your composer.json.
+Installation is easy with composer just run.
 
-```json
-{
-	"require": {
-		"wyrihaximus/s3-parallel-upload": "dev-master"
-	}
-}
+```sh
+composer require wyrihaximus/s3-parallel-upload
 ```
 
 ## Basic Usage ##


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
